### PR TITLE
Testing with Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     # This environment tests Python 2 support
     - DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="false"
       NUMPY_VERSION="1.9.2" SCIPY_VERSION="0.16.0"
-      SKLEARN_VERSION="0.16cond.1" MATPLOTLIB_VERSION="1.4.3"
+      SKLEARN_VERSION="0.16.1" MATPLOTLIB_VERSION="1.4.3"
       INSTALL_SCOT="true" RUN_EXAMPLES="false"
 
     # This environment tests Python 3 support

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ env:
   matrix:
     #- DISTRIB="ubuntu" PYTHON_VERSION="2.7" INSTALL_ATLAS="true"
 
-    # This environment tests the oldest supported anaconda env
+    # This environment tests Python 2 support
     - DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="false"
-      NUMPY_VERSION="1.8.1" SCIPY_VERSION="0.13.3"
-      SKLEARN_VERSION="0.14.1" MATPLOTLIB_VERSION="1.3.1"
+      NUMPY_VERSION="1.9.2" SCIPY_VERSION="0.16.0"
+      SKLEARN_VERSION="0.16cond.1" MATPLOTLIB_VERSION="1.4.3"
       INSTALL_SCOT="true" RUN_EXAMPLES="false"
 
-    # This environment tests the newest supported anaconda env
-    - DISTRIB="conda" PYTHON_VERSION="3.3" INSTALL_MKL="false"
-      NUMPY_VERSION="1.8.1" SCIPY_VERSION="0.13.3"
-      SKLEARN_VERSION="0.14.1" MATPLOTLIB_VERSION="1.3.1"
+    # This environment tests Python 3 support
+    - DISTRIB="conda" PYTHON_VERSION="3.4" INSTALL_MKL="false"
+      NUMPY_VERSION="1.9.2" SCIPY_VERSION="0.16.0"
+      SKLEARN_VERSION="0.16.1" MATPLOTLIB_VERSION="1.4.3"
       COVERAGE="true"
       INSTALL_SCOT="true" RUN_EXAMPLES="false"
       


### PR DESCRIPTION
I've updated the testing environment to use Python version 3.4 instead of 3.3, and also updated the library dependencies (numpy, scipy, sklearn, matplotlib) to the newest versions available in Anaconda.