### PR TITLE
Added Badges to documentation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -33,3 +33,12 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
+Badges
+======
+
+* .. image:: https://travis-ci.org/scot-dev/scot.svg
+   :target: https://travis-ci.org/scot-dev/scot
+
+* .. image:: https://coveralls.io/repos/scot-dev/scot/badge.svg?branch=master&service=github 
+   :target: https://coveralls.io/github/scot-dev/scot?branch=master
+   


### PR DESCRIPTION
The badges serve two purposes:

1. Assert, at a glance, the status of the sources
2. Provide quick links to the tool websites (travis, coveralls, ...)