### PR TITLE
Fix ACM computation (in master)

### DIFF
--- a/examples/misc/connectivity.py
+++ b/examples/misc/connectivity.py
@@ -39,7 +39,7 @@ data = scot.datatools.cut_segments(raweeg, triggers, 3 * fs, 4 * fs)
 #
 # We simply choose a VAR model order of 35, and reduction to 4 components
 # (that's not a lot).
-ws = scot.Workspace({'model_order': 35}, reducedim=4, fs=fs, locations=locs)
+ws = scot.Workspace({'model_order': 40}, reducedim=4, fs=fs, locations=locs)
 
 
 # Perform CSPVARICA and plot components

--- a/scot/utils.py
+++ b/scot/utils.py
@@ -89,7 +89,11 @@ def acm(x, l):
     c : ndarray, shape = [nchannels, n_channels]
         Autocovariance matrix of `x` at lag `l`.
     """
-    x = np.atleast_3d(x)
+    x = np.asarray(x)
+    if x.ndim == 1:
+        x = x.reshape((-1, 1, 1))
+    elif x.ndim == 2:
+        x = x.reshape((x.shape[0], x.shape[1], 1))
 
     if l > x.shape[0]-1:
         raise AttributeError("lag exceeds data length")
@@ -106,10 +110,10 @@ def acm(x, l):
 
     c = np.zeros((x.shape[1], x.shape[1]))
     for t in range(x.shape[2]):
-        c += a[:, :, t].T.dot(b[:, :, t]) / x.shape[0]
+        c += a[:, :, t].T.dot(b[:, :, t]) / a.shape[0]
     c /= x.shape[2]
 
-    return c
+    return c.T
 
 
 #noinspection PyPep8Naming

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,8 @@
 # http://opensource.org/licenses/MIT
 # Copyright (c) 2013 SCoT Development Team
 
+from __future__ import division
+
 import unittest
 
 from importlib import import_module
@@ -41,16 +43,16 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(5, obj.squareone(2))
             self.assertEqual(10, obj.squareone(3))
 
-        def test_acm(self):
-            v = np.array([[1], [2], [0], [0]]*2)
+        def test_acm_1d(self):
+            """Test autocorrelation matrix for 1D input"""
+            v = np.array([1, 2, 0, 0, 1, 2, 0, 0])
             acm = lambda l: scot.utils.acm(v, l)
+
             self.assertEqual(np.mean(v**2), acm(0))
-            self.assertEqual(0.5, acm(1))
-            self.assertEqual(0, acm(2))
-            self.assertEqual(0.25, acm(3))
-            self.assertEqual(acm(0)*0.5, acm(4))
-            self.assertEqual(acm(1)*0.5, acm(5))
-            self.assertEqual(0, acm(6))
+            for l in range(1, 6):
+                print(l)
+                self.assertEqual(np.correlate(v[l:], v[:-l]) / (len(v) - l),
+                                 acm(l))
 
         def test_cuthill(self):
             A = np.array([[0,0,1,1], [0,0,0,0], [1,0,1,0], [1,0,0,0]])

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 
 from scot.varbase import VARBase as VAR
-from scot.datatools import dot_special
+from scot.utils import acm
 
 epsilon = 1e-10
 
@@ -79,20 +79,6 @@ class TestVAR(unittest.TestCase):
         r[3:,1,:] = r[:-3,0,:]              # create cross-correlation at lag 3
         p = var.test_whiteness(20)
         self.assertLessEqual(p, 0.01)       # now test should be significant
-
-
-def acm(x, l):
-    if l == 0:
-        a, b = x, x
-    else:
-        a = x[l:, :, :]
-        b = x[0:-l, :, :]
-
-    c = np.dot(a[:, :, 0].T, b[:, :, 0]) / a.shape[0]
-    for t in range(1, x.shape[2]):
-        c += np.dot(a[:, :, t].T, b[:, :, t]) / a.shape[0]
-
-    return c.T / x.shape[2]
 
 
 def main():


### PR DESCRIPTION
The way we compute the autocorrelationmatrix has impact on the results of the whiteness test.

I want to have the new version in master too so we can better verify the transpose branch.

With the new version residuals are non-white in the connectivity example, so i increased the model order to get a better model.