### PR TITLE
[Hotfix] New config broke examples

### DIFF
--- a/examples/misc/features.py
+++ b/examples/misc/features.py
@@ -15,7 +15,6 @@ from sklearn.cross_validation import KFold
 from sklearn.metrics import confusion_matrix
 
 import scot
-import scot.backend_sklearn  # use scikit-learn backend
 import scot.xvschema
 
 # The data set contains a continuous 45 channel EEG recording of a motor
@@ -36,6 +35,10 @@ locs = midata.locations
 
 # Set random seed for repeatable results
 np.random.seed(42)
+
+
+# Switch backend to scikit-learn
+scot.backend.activate('sklearn')
 
 
 # Set up analysis object

--- a/examples/misc/validation.py
+++ b/examples/misc/validation.py
@@ -52,7 +52,7 @@ for p in [22, 33]:
     print('Model order:', p)
 
     print('    Performing CSPVARICA')
-    var = scot.config.backend['var'](p)
+    var = scot.backend['var'](p)
     result = cspvarica(data, var, classes, m)
 
     if result.a.is_stable():

--- a/scot/ooapi.py
+++ b/scot/ooapi.py
@@ -95,6 +95,7 @@ class Workspace(object):
         self._plotting = None
 
         if self.backend_ is None:
+            from . import backend
             self.backend_ = backend
 
         try:

--- a/scot/ooapi.py
+++ b/scot/ooapi.py
@@ -15,7 +15,7 @@ example usage of the low-level API.
 
 import numpy as np
 
-from . import backend
+from . import backend as global_backend
 from .varica import mvarica, cspvarica
 from .plainica import plainica
 from .datatools import dot_special, atleast_3d
@@ -76,7 +76,7 @@ class Workspace(object):
         self.locations_ = locations
         self.reducedim_ = reducedim
         self.nfft_ = nfft
-        self.backend_ = backend
+        self.backend_ = backend if backend is not None else global_backend
 
         self.trial_mask_ = []
 
@@ -93,10 +93,6 @@ class Workspace(object):
         self.plot_f_range = [0, fs/2]
 
         self._plotting = None
-
-        if self.backend_ is None:
-            from . import backend
-            self.backend_ = backend
 
         try:
             self.var_ = self.backend_['var'](**var)

--- a/tests/test_ooapi.py
+++ b/tests/test_ooapi.py
@@ -237,3 +237,8 @@ class TestMVARICA(unittest.TestCase):
                 api.get_bootstrap_connectivity('PHI', plot=fig, repeats=5)
                 api.get_tf_connectivity('PHI', winlen=2, winstep=1, plot=fig)
                 api.compare_conditions([0], [1], 'PHI', plot=fig, repeats=5)
+
+    def testBackendRegression(self):
+        """Regression test for Github issue #103."""
+        ws = scot.Workspace({'model_order': 3}, backend=None)
+        self.assertIsNotNone(ws.backend_)


### PR DESCRIPTION
Actually it broke default backend assignment in `Workspace`.

Should fix #103.