### PR TITLE
Fixed overflow in Infomax

### DIFF
--- a/tests/test_ooapi.py
+++ b/tests/test_ooapi.py
@@ -50,7 +50,7 @@ class TestMVARICA(unittest.TestCase):
         l, t = 1000, 100
 
         # generate VAR sources with non-gaussian innovation process, otherwise ICA won't work
-        noisefunc = lambda: np.random.normal(size=(1, m0)) ** 3
+        noisefunc = lambda: np.random.normal(size=(1, m0)) ** 3 / 1e3
 
         var = VAR(2)
         var.coef = b0
@@ -117,7 +117,7 @@ class TestMVARICA(unittest.TestCase):
         t = len(cl)
 
         # generate VAR sources with non-gaussian innovation process, otherwise ICA won't work
-        noisefunc = lambda: np.random.normal(size=(1, m0)) ** 3
+        noisefunc = lambda: np.random.normal(size=(1, m0)) ** 3 / 1e3
 
         var = VAR(2)
         var.coef = b01

--- a/tests/test_plainica.py
+++ b/tests/test_plainica.py
@@ -35,7 +35,7 @@ class TestICA(unittest.TestCase):
         l, t = 100, 100
 
         # generate VAR sources with non-gaussian innovation process, otherwise ICA won't work
-        noisefunc = lambda: np.random.normal(size=(1, m0)) ** 3
+        noisefunc = lambda: np.random.normal(size=(1, m0)) ** 3 / 1e3
 
         var = VAR(1)
         var.coef = b0

--- a/tests/test_varica.py
+++ b/tests/test_varica.py
@@ -38,7 +38,7 @@ class TestMVARICA(unittest.TestCase):
         l, t = 1000, 100
 
         # generate VAR sources with non-gaussian innovation process, otherwise ICA won't work
-        noisefunc = lambda: np.random.normal(size=(1, m0)) ** 3
+        noisefunc = lambda: np.random.normal(size=(1, m0)) ** 3 / 1e3
 
         var = VAR(2)
         var.coef = b0


### PR DESCRIPTION
The overflow warning we saw in infomax was caused by testing data that had values across several orders of magnitude. 

Since this is not realistic for EEG anyway I simply reduced the magnitude of the data to make the warning go away...