### PR TITLE
Anaconda 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
       INSTALL_SCOT="true" RUN_EXAMPLES="false"
 
     # This environment tests Python 2 support
-    - DISTRIB="conda" PYTHON_VERSION="2.7" USE_MKL="false"
+    - DISTRIB="conda" PYTHON_VERSION="2.7" USE_MKL="true"
       NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0"
       SKLEARN_VERSION="0.17.0" MATPLOTLIB_VERSION="1.5.1"
       INSTALL_SCOT="true" RUN_EXAMPLES="false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,21 @@ env:
       NUMPY_VERSION="1.8.0" SCIPY_VERSION="0.13.3"
       SKLEARN_VERSION="0.15.0" MATPLOTLIB_VERSION="1.4.0"
       INSTALL_SCOT="true" RUN_EXAMPLES="false"
+      COVERAGE="false"
 
     # This environment tests Python 2 support
     - DISTRIB="conda" PYTHON_VERSION="2.7" USE_MKL="true"
       NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0"
       SKLEARN_VERSION="0.17.0" MATPLOTLIB_VERSION="1.5.1"
       INSTALL_SCOT="true" RUN_EXAMPLES="false"
+      COVERAGE="false"
 
     # This environment tests Python 3 support
     - DISTRIB="conda" PYTHON_VERSION="3.5" USE_MKL="true"
       NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0"
       SKLEARN_VERSION="0.17.0" MATPLOTLIB_VERSION="1.5.1"
-      COVERAGE="true"
       INSTALL_SCOT="true" RUN_EXAMPLES="false"
+      COVERAGE="true"
       
 install: source distributions/ci/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,19 @@ env:
     #- DISTRIB="ubuntu" PYTHON_VERSION="2.7" INSTALL_ATLAS="true"
 
     # This environment tests compatibility with oldest supported package versions
-    - DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="false"
+    - DISTRIB="conda" PYTHON_VERSION="2.7" USE_MKL="false"
       NUMPY_VERSION="1.8.0" SCIPY_VERSION="0.13.3"
       SKLEARN_VERSION="0.15.0" MATPLOTLIB_VERSION="1.4.0"
       INSTALL_SCOT="true" RUN_EXAMPLES="false"
 
     # This environment tests Python 2 support
-    - DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MKL="false"
+    - DISTRIB="conda" PYTHON_VERSION="2.7" USE_MKL="false"
       NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0"
       SKLEARN_VERSION="0.17.0" MATPLOTLIB_VERSION="1.5.1"
       INSTALL_SCOT="true" RUN_EXAMPLES="false"
 
     # This environment tests Python 3 support
-    - DISTRIB="conda" PYTHON_VERSION="3.4" INSTALL_MKL="false"
+    - DISTRIB="conda" PYTHON_VERSION="3.4" USE_MKL="true"
       NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0"
       SKLEARN_VERSION="0.17.0" MATPLOTLIB_VERSION="1.5.1"
       COVERAGE="true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
       INSTALL_SCOT="true" RUN_EXAMPLES="false"
 
     # This environment tests Python 3 support
-    - DISTRIB="conda" PYTHON_VERSION="3.4" USE_MKL="true"
+    - DISTRIB="conda" PYTHON_VERSION="3.5" USE_MKL="true"
       NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0"
       SKLEARN_VERSION="0.17.0" MATPLOTLIB_VERSION="1.5.1"
       COVERAGE="true"

--- a/distributions/ci/install.sh
+++ b/distributions/ci/install.sh
@@ -25,13 +25,13 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     # Configure the conda environment and put it in the path using the
     # provided versions
-    if [[ "$INSTALL_MKL" == "true" ]]; then
+    if [[ "$USE_MKL" == "true" ]]; then
         conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
             numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION numpy scipy \
             scikit-learn=$SKLEARN_VERSION matplotlib=$MATPLOTLIB_VERSION \
-            libgfortran mkl
+            libgfortran
     else
-        conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
+        conda create -n testenv --yes python=$PYTHON_VERSION nomkl pip nose \
             numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION numpy scipy \
             scikit-learn=$SKLEARN_VERSION matplotlib=$MATPLOTLIB_VERSION \
             libgfortran

--- a/distributions/ci/run_tests.sh
+++ b/distributions/ci/run_tests.sh
@@ -22,9 +22,9 @@ if [[ "$INSTALL_SCOT" == "true" ]]; then
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then
-    xvfb-run --server-args="-screen 0 1024x768x24" nosetests --with-coverage --cover-package=scot,eegtopo --cover-inclusive --cover-branches;
+    xvfb-run --server-args="-screen 0 1024x768x24" nosetests -v --with-coverage --cover-package=scot,eegtopo --cover-inclusive --cover-branches;
 else
-    xvfb-run --server-args="-screen 0 1024x768x24" nosetests;
+    xvfb-run --server-args="-screen 0 1024x768x24" nosetests -v;
 fi
 
 if [[ "$RUN_EXAMPLES" == "true" ]]; then

--- a/run_tests2.sh
+++ b/run_tests2.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-nosetests2 --with-coverage --cover-package=scot,eegtopo --cover-erase --cover-inclusive --cover-branches -x
+nosetests2 --with-coverage --cover-package=scot,eegtopo --cover-erase --cover-inclusive --cover-branches -x -v
 

--- a/run_tests3.sh
+++ b/run_tests3.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-nosetests3 --with-coverage --cover-package=scot,eegtopo --cover-erase --cover-inclusive --cover-branches -x
+nosetests3 --with-coverage --cover-package=scot,eegtopo --cover-erase --cover-inclusive --cover-branches -x -v
 


### PR DESCRIPTION
Anaconda 2.5 comes by default with MKL. It can be disabled by installing `nomkl`.
Details [here](https://www.continuum.io/blog/developer-blog/anaconda-25-release-now-mkl-optimizations).