### PR TITLE
Random phase

### DIFF
--- a/scot/datatools.py
+++ b/scot/datatools.py
@@ -119,7 +119,7 @@ def randomize_phase(data):
     """Phase randomization.
 
     This function randomizes the spectral phase of the input data along the
-    first dimension.
+    last dimension.
 
     Parameters
     ----------

--- a/scot/datatools.py
+++ b/scot/datatools.py
@@ -144,14 +144,14 @@ def randomize_phase(data):
         from pylab import *
         from scot.datatools import randomize_phase
         np.random.seed(1234)
-        s = np.sin(np.linspace(0,10*np.pi,1000)).T
-        x = np.vstack([s, np.sign(s)]).T
+        s = np.sin(np.linspace(0,10*np.pi,1000))
+        x = np.vstack([s, np.sign(s)])
         y = randomize_phase(x)
         subplot(2,1,1)
         title('Phase randomization of sine wave and rectangular function')
-        plot(x), axis([0,1000,-3,3])
+        plot(x.T + [1.5, -1.5]), axis([0,1000,-3,3])
         subplot(2,1,2)
-        plot(y), axis([0,1000,-3,3])
+        plot(y.T + [1.5, -1.5]), axis([0,1000,-3,3])
         plt.show()
     """
     data = np.asarray(data)


### PR DESCRIPTION
The doctest example of `randomize_phase` performed randomizaton along the wrong axis. (Did this happen when changing data orientation?)