### PR TITLE
Cross validation tests with scikit-learn

### DIFF
--- a/tests/test_xvschema.py
+++ b/tests/test_xvschema.py
@@ -5,11 +5,12 @@
 import unittest
 
 import numpy as np
+from numpy.testing import assert_array_equal
 
 import scot.xvschema
 
 
-class Tests(unittest.TestCase):
+class TestBuiltin(unittest.TestCase):
     def setUp(self):
         pass
 
@@ -61,3 +62,45 @@ class Tests(unittest.TestCase):
             for t in train:
                 self.assertTrue(t not in test)
         self.assertEqual(n + 1, n_blocks)
+
+
+class TestSklearn(unittest.TestCase):
+    def setUp(self):
+        try:
+            import sklearn
+        except ImportError:
+            self.skipTest("could not import scikit-learn")
+
+    def tearDown(self):
+        pass
+
+    def test_leave1out(self):
+        from sklearn.cross_validation import LeaveOneOut
+        n_trials = 10
+        xv1 = scot.xvschema.multitrial(n_trials)
+        xv2 = LeaveOneOut(n_trials)
+        self._comparexv(xv1, xv2)
+
+    def test_kfold(self):
+        from sklearn.cross_validation import KFold
+        n_trials = 15
+        n_blocks = 5
+        xv1 = scot.xvschema.make_nfold(n_blocks)(n_trials)
+        xv2 = KFold(n_trials, n_folds=n_blocks, shuffle=False)
+        self._comparexv(xv1, xv2)
+
+    def test_application(self):
+        from scot.var import VAR
+        from sklearn.cross_validation import LeaveOneOut, KFold
+        np.random.seed(42)
+        x = np.random.randn(10, 3, 15)
+
+        var = VAR(3, xvschema=lambda n, _: LeaveOneOut(n)).optimize_delta_bisection(x)
+        self.assertGreater(var.delta, 0)
+        var = VAR(3, xvschema=lambda n, _: KFold(n, 5)).optimize_delta_bisection(x)
+        self.assertGreater(var.delta, 0)
+
+    def _comparexv(self, xv1, xv2):
+        for (a, b), (c, d) in zip(xv1, xv2):
+            assert_array_equal(a, c)
+            assert_array_equal(b, d)


### PR DESCRIPTION
I've added some tests that compare our and sklearn's cross validation routines. They also use sklearn cross-validation in VAR optimization. However, this requires wrapping of the function, because our functions take a `skipstep` argument that does not exist in scikit-learn.

Resolves #132 