### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Required: numpy, scipy
 
 Optional: matplotlib, scikit-learn
 
-The lowest supported versions of these libraries are numpy 1.8.0, scipy 0.13.3, scikit-learn 0.15.0, and
+The lowest supported versions of these libraries are numpy 1.8.2, scipy 0.13.3, scikit-learn 0.15.0, and
 matplotlib 1.4.0. Lower versions may work but are not tested.
 
 


### PR DESCRIPTION
Oldest supported `numpy` is now 1.8.2 due to conda packaging issues (#149)