### PR TITLE
Change ICA default to extended Infomax

### DIFF
--- a/scot/backend_builtin.py
+++ b/scot/backend_builtin.py
@@ -16,7 +16,8 @@ from .external.infomax_ import infomax
 def generate():
     def wrapper_infomax(data, random_state=None):
         """Call Infomax (adapted from MNE) for ICA calculation."""
-        u = infomax(datatools.cat_trials(data).T, random_state=random_state).T
+        u = infomax(datatools.cat_trials(data).T, extended=True,
+                    random_state=random_state).T
         m = sp.linalg.pinv(u)
         return m, u
 
@@ -28,6 +29,7 @@ def generate():
         return c, d, y
 
     def wrapper_csp(x, cl, reducedim):
+        """Call SCoT's CSP algorithm."""
         c, d = csp.csp(x, cl, numcomp=reducedim)
         y = datatools.dot_special(c.T, x)
         return c, d, y


### PR DESCRIPTION
Fixes #53. I think standard Infomax has problems with estimating sources as discussed in #160. Although I'm not sure that the toy example shown there is related to differences in components obtained with Anaconda vs. Homebrew Python, extended Infomax is the default choice for anyone applying ICA to EEG data. Therefore, we should use it too.