### PR TITLE
Fix wrong axis argument when removing activations

### DIFF
--- a/scot/ooapi.py
+++ b/scot/ooapi.py
@@ -364,7 +364,7 @@ class Workspace(object):
         self.mixing_ = np.delete(self.mixing_, sources, 0)
         self.unmixing_ = np.delete(self.unmixing_, sources, 1)
         if self.activations_ is not None:
-            self.activations_ = np.delete(self.activations_, sources, 1)
+            self.activations_ = np.delete(self.activations_, sources, 0)
         self.var_model_ = None
         self.var_cov_ = None
         self.connectivity_ = None


### PR DESCRIPTION
I think the axis argument is wrong - we want to delete components, which I think correspond to the rows. @mbillingr, can you confirm? And if this is really a bug, why didn't we notice this before (e.g. in our tests)?