### PR TITLE
Modernize tests (switch to pytest)

### DIFF
--- a/scot/backend_mne.py
+++ b/scot/backend_mne.py
@@ -11,6 +11,11 @@ from . import datatools
 from . import backend
 from . import backend_builtin as builtin
 
+try:
+    import mne
+except ImportError:
+    mne = None
+
 
 def generate():
     from mne.preprocessing.infomax_ import infomax
@@ -36,4 +41,5 @@ def generate():
     return backend
 
 
-backend.register('mne', generate)
+if mne is not None:
+    backend.register('mne', generate)

--- a/scot/backend_sklearn.py
+++ b/scot/backend_sklearn.py
@@ -5,7 +5,7 @@
 """Use scikit-learn routines as backend."""
 
 from __future__ import absolute_import
-import scipy as sp
+import numpy as np
 
 from .datatools import atleast_3d, cat_trials, dot_special
 from . import backend
@@ -19,7 +19,7 @@ def generate():
 
     def wrapper_fastica(data, random_state=None):
         """Call FastICA implementation from scikit-learn."""
-        ica = FastICA(random_state=random_state)
+        ica = FastICA(random_state=random_state, whiten="arbitrary-variance")
         ica.fit(cat_trials(data).T)
         u = ica.components_.T
         m = ica.mixing_.T
@@ -84,7 +84,7 @@ def generate():
             self.coef = self.fitting_model.coef_
 
             self.residuals = data - self.predict(data)
-            self.rescov = sp.cov(cat_trials(self.residuals[:, :, self.p:]))
+            self.rescov = np.cov(cat_trials(self.residuals[:, :, self.p:]))
 
             return self
 

--- a/scot/connectivity.py
+++ b/scot/connectivity.py
@@ -154,7 +154,7 @@ class Connectivity(object):
 
     @memoize
     def A(self):
-        """Spectral VAR coefficients.
+        r"""Spectral VAR coefficients.
 
         .. math:: \mathbf{A}(f) = \mathbf{I} - \sum_{k=1}^{p} \mathbf{a}^{(k)}
                   \mathrm{e}^{-2\pi f}
@@ -164,7 +164,7 @@ class Connectivity(object):
 
     @memoize
     def H(self):
-        """VAR transfer function.
+        r"""VAR transfer function.
 
         .. math:: \mathbf{H}(f) = \mathbf{A}(f)^{-1}
         """
@@ -172,7 +172,7 @@ class Connectivity(object):
 
     @memoize
     def S(self):
-        """Cross-spectral density.
+        r"""Cross-spectral density.
 
         .. math:: \mathbf{S}(f) = \mathbf{H}(f) \mathbf{C} \mathbf{H}'(f)
         """
@@ -188,7 +188,7 @@ class Connectivity(object):
 
     @memoize
     def logS(self):
-        """Logarithmic cross-spectral density.
+        r"""Logarithmic cross-spectral density.
 
         .. math:: \mathrm{logS}(f) = \log | \mathbf{S}(f) |
         """
@@ -196,7 +196,7 @@ class Connectivity(object):
 
     @memoize
     def absS(self):
-        """Absolute cross-spectral density.
+        r"""Absolute cross-spectral density.
 
         .. math:: \mathrm{absS}(f) = | \mathbf{S}(f) |
         """
@@ -204,7 +204,7 @@ class Connectivity(object):
 
     @memoize
     def G(self):
-        """Inverse cross-spectral density.
+        r"""Inverse cross-spectral density.
 
         .. math:: \mathbf{G}(f) = \mathbf{A}(f) \mathbf{C}^{-1} \mathbf{A}'(f)
         """
@@ -219,7 +219,7 @@ class Connectivity(object):
 
     @memoize
     def logG(self):
-        """Logarithmic inverse cross-spectral density.
+        r"""Logarithmic inverse cross-spectral density.
 
         .. math:: \mathrm{logG}(f) = \log | \mathbf{G}(f) |
         """
@@ -227,7 +227,7 @@ class Connectivity(object):
 
     @memoize
     def COH(self):
-        """Coherence.
+        r"""Coherence.
 
         .. math:: \mathrm{COH}_{ij}(f) = \\frac{S_{ij}(f)}
                                                {\sqrt{S_{ii}(f) S_{jj}(f)}}
@@ -254,7 +254,7 @@ class Connectivity(object):
 
     @memoize
     def pCOH(self):
-        """Partial coherence.
+        r"""Partial coherence.
 
         .. math:: \mathrm{pCOH}_{ij}(f) = \\frac{G_{ij}(f)}
                                                 {\sqrt{G_{ii}(f) G_{jj}(f)}}
@@ -271,7 +271,7 @@ class Connectivity(object):
 
     @memoize
     def PDC(self):
-        """Partial directed coherence.
+        r"""Partial directed coherence.
 
         .. math:: \mathrm{PDC}_{ij}(f) = \\frac{A_{ij}(f)}
                                                {\sqrt{A_{:j}'(f) A_{:j}(f)}}
@@ -287,7 +287,7 @@ class Connectivity(object):
 
     @memoize
     def sPDC(self):
-        """Squared partial directed coherence.
+        r"""Squared partial directed coherence.
 
         .. math:: \mathrm{sPDC}_{ij}(f) = \\frac{|A_{ij}(f)|^2}
                                                 {\mathbf{1}^T | A_{:j}(f) |^2}
@@ -303,7 +303,7 @@ class Connectivity(object):
 
     @memoize
     def ffPDC(self):
-        """Full frequency partial directed coherence.
+        r"""Full frequency partial directed coherence.
 
         .. math:: \mathrm{ffPDC}_{ij}(f) =
            \\frac{A_{ij}(f)}{\sqrt{\sum_f A_{:j}'(f) A_{:j}(f)}}
@@ -314,7 +314,7 @@ class Connectivity(object):
 
     @memoize
     def PDCF(self):
-        """Partial directed coherence factor.
+        r"""Partial directed coherence factor.
 
         .. math:: \mathrm{PDCF}_{ij}(f) =
         \\frac{A_{ij}(f)}{\sqrt{A_{:j}'(f) \mathbf{C}^{-1} A_{:j}(f)}}
@@ -332,7 +332,7 @@ class Connectivity(object):
 
     @memoize
     def GPDC(self):
-        """Generalized partial directed coherence.
+        r"""Generalized partial directed coherence.
 
         .. math:: \mathrm{GPDC}_{ij}(f) = \\frac{|A_{ij}(f)|}
         {\sigma_i \sqrt{A_{:j}'(f) \mathrm{diag}(\mathbf{C})^{-1} A_{:j}(f)}}
@@ -350,7 +350,7 @@ class Connectivity(object):
 
     @memoize
     def DTF(self):
-        """Directed transfer function.
+        r"""Directed transfer function.
 
         .. math:: \mathrm{DTF}_{ij}(f) = \\frac{H_{ij}(f)}
                                                {\sqrt{H_{i:}(f) H_{i:}'(f)}}
@@ -366,7 +366,7 @@ class Connectivity(object):
 
     @memoize
     def ffDTF(self):
-        """Full frequency directed transfer function.
+        r"""Full frequency directed transfer function.
 
         .. math:: \mathrm{ffDTF}_{ij}(f) =
                   \\frac{H_{ij}(f)}{\sqrt{\sum_f H_{i:}(f) H_{i:}'(f)}}
@@ -384,7 +384,7 @@ class Connectivity(object):
 
     @memoize
     def dDTF(self):
-        """Direct directed transfer function.
+        r"""Direct directed transfer function.
 
         .. math:: \mathrm{dDTF}_{ij}(f) = |\mathrm{pCOH}_{ij}(f)|
                   \mathrm{ffDTF}_{ij}(f)
@@ -400,7 +400,7 @@ class Connectivity(object):
 
     @memoize
     def GDTF(self):
-        """Generalized directed transfer function.
+        r"""Generalized directed transfer function.
 
         .. math:: \mathrm{GPDC}_{ij}(f) = \\frac{\sigma_j |H_{ij}(f)|}
             {\sqrt{H_{i:}(f) \mathrm{diag}(\mathbf{C}) H_{i:}'(f)}}

--- a/scot/connectivity_statistics.py
+++ b/scot/connectivity_statistics.py
@@ -180,7 +180,7 @@ def bootstrap_connectivity(measures, data, var, nfft=512, repeats=100,
     if num_samples is None:
         num_samples = t
 
-    mask = lambda r: rng.random_integers(0, data.shape[0]-1, num_samples)
+    mask = lambda r: rng.randint(0, data.shape[0], num_samples)
 
     par, func = parallel_loop(_calc_bootstrap, n_jobs=n_jobs, verbose=verbose)
     output = par(func(data[mask(r), :, :], var, measures, nfft)

--- a/scot/eegtopo/warp_layout.py
+++ b/scot/eegtopo/warp_layout.py
@@ -102,7 +102,7 @@ def _project_on_ellipsoid(c, r, locations):
 
     fun = lambda x: np.sum((x.reshape(p0.shape) - p0)**2)              # minimize distance between new and old points
     con = lambda x: np.sum(x.reshape(p0.shape)**2 / r**2, axis=1) - 1  # new points constrained to surface of ellipsoid
-    res = sp.optimize.minimize(fun, p, constraints={'type': 'eq', 'fun': con}, method='SLSQP')
+    res = sp.optimize.minimize(fun, p.ravel(), constraints={'type': 'eq', 'fun': con}, method='SLSQP')
 
     return res['x'].reshape(p0.shape) + c
 

--- a/scot/ooapi.py
+++ b/scot/ooapi.py
@@ -707,7 +707,7 @@ class Workspace(object):
                 diagonal = -1
             elif self.plot_diagonal == 'fill':
                 diagonal = 0
-            elif self.plot_diagonal is 'S':
+            elif self.plot_diagonal == 'S':
                 diagonal = -1
                 self.set_used_labels(labels1)
                 sa = self.get_bootstrap_connectivity('absS', repeats, num_samples)

--- a/scot/plotting.py
+++ b/scot/plotting.py
@@ -140,8 +140,8 @@ def plot_sources(topo, mixmaps, unmixmaps, global_scale=None, fig=None):
         mmin = -mmax
         mrange = [mmin, mmax]
 
-    y = np.floor(np.sqrt(m * 3 / 4))
-    x = np.ceil(m / y)
+    y = int(np.floor(np.sqrt(m * 3 / 4)))
+    x = int(np.ceil(m / y))
 
     if fig is None:
         fig = new_figure()

--- a/scot/plotting.py
+++ b/scot/plotting.py
@@ -647,7 +647,7 @@ def plot_whiteness(var, h, repeats=1000, axis=None):
     if axis is None:
         axis = current_axis()
 
-    pdf, _, _ = axis.hist(q0, 30, normed=True, label='surrogate distribution')
+    pdf, _, _ = axis.hist(q0, 30, density=True, label='surrogate distribution')
     axis.plot([q,q], [0,np.max(pdf)], 'r-', label='fitted model')
 
     #df = m*m*(h-p)

--- a/scot/tests/test_csp.py
+++ b/scot/tests/test_csp.py
@@ -5,7 +5,7 @@
 import unittest
 
 import numpy as np
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 
 from scot.datatools import dot_special
 from scot.csp import csp

--- a/scot/tests/test_datatools.py
+++ b/scot/tests/test_datatools.py
@@ -38,7 +38,7 @@ class TestDataMangling(unittest.TestCase):
                           rawdata, triggers, -10.1, 50)
 
         for it in range(len(triggers)):
-            a = rawdata[:, triggers[it] + start: triggers[it] + stop]
+            a = rawdata[:, triggers[it] + int(start): triggers[it] + int(stop)]
             b = x[it, :, :]
             self.assertTrue(np.all(a == b))
 

--- a/scot/tests/test_eegtopo/test_warp.py
+++ b/scot/tests/test_eegtopo/test_warp.py
@@ -5,7 +5,7 @@
 import unittest
 import numpy as np
 
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 
 from scot.eegtopo.warp_layout import warp_locations
 from scot.eegtopo.eegpos3d import positions as _eeglocs

--- a/scot/tests/test_ooapi.py
+++ b/scot/tests/test_ooapi.py
@@ -18,7 +18,11 @@ class TestMVARICA(unittest.TestCase):
         pass
 
     def tearDown(self):
-        pass
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            return
+        plt.close("all")
 
     def testTrivia(self):
         api = scot.Workspace(VAR(1))
@@ -26,26 +30,25 @@ class TestMVARICA(unittest.TestCase):
 
     def testExceptions(self):
         self.assertRaises(TypeError, scot.Workspace)
-        api = scot.Workspace({'model_order':50})
+        api = scot.Workspace({"model_order": 50})
         self.assertRaises(RuntimeError, api.remove_sources, [])
         self.assertRaises(RuntimeError, api.do_mvarica)
         self.assertRaises(RuntimeError, api.do_cspvarica)
         self.assertRaises(RuntimeError, api.do_ica)
         self.assertRaises(RuntimeError, api.fit_var)
         self.assertRaises(TypeError, api.get_connectivity)
-        self.assertRaises(RuntimeError, api.get_connectivity, 'S')
-        self.assertRaises(RuntimeError, api.get_tf_connectivity, 'PDC', 10, 1)
-        api.set_data([[[1,1], [1,1]], [[1,1], [1,1]]])
+        self.assertRaises(RuntimeError, api.get_connectivity, "S")
+        self.assertRaises(RuntimeError, api.get_tf_connectivity, "PDC", 10, 1)
+        api.set_data([[[1, 1], [1, 1]], [[1, 1], [1, 1]]])
         self.assertRaises(RuntimeError, api.do_cspvarica)
-        
+
     def testModelIdentification(self):
-        """ generate VAR signals, mix them, and see if MVARICA can reconstruct the signals
-            do this for every backend """
+        """generate VAR signals, mix them, and see if MVARICA can reconstruct the signals
+        do this for every backend"""
 
         # original model coefficients
         b0 = np.zeros((3, 6))
-        b0[1:3, 2:6] = [[0.4, -0.2, 0.3, 0.0],
-                        [-0.7, 0.0, 0.9, 0.0]]
+        b0[1:3, 2:6] = [[0.4, -0.2, 0.3, 0.0], [-0.7, 0.0, 0.9, 0.0]]
         m0 = b0.shape[0]
         l, t = 1000, 100
 
@@ -57,15 +60,17 @@ class TestMVARICA(unittest.TestCase):
         sources = var.simulate([l, t], noisefunc)
 
         # simulate volume conduction... 3 sources measured with 7 channels
-        mix = [[0.5, 1.0, 0.5, 0.2, 0.0, 0.0, 0.0],
-               [0.0, 0.2, 0.5, 1.0, 0.5, 0.2, 0.0],
-               [0.0, 0.0, 0.0, 0.2, 0.5, 1.0, 0.5]]
+        mix = [
+            [0.5, 1.0, 0.5, 0.2, 0.0, 0.0, 0.0],
+            [0.0, 0.2, 0.5, 1.0, 0.5, 0.2, 0.0],
+            [0.0, 0.0, 0.0, 0.2, 0.5, 1.0, 0.5],
+        ]
         data = datatools.dot_special(np.transpose(mix), sources)
 
         for backend_name, backend_gen in scot.backend.items():
-
-            api = scot.Workspace({'model_order': 2}, backend=backend_gen(),
-                                 reducedim=0.99)
+            api = scot.Workspace(
+                {"model_order": 2}, backend=backend_gen(), reducedim=0.99
+            )
 
             api.set_data(data)
 
@@ -73,16 +78,32 @@ class TestMVARICA(unittest.TestCase):
             #  - default setting of 0.99 variance should reduce to 3 channels with this data
             #  - automatically determine delta (enough data, so it should most likely be 0)
             api.do_mvarica()
-            #result = varica.mvarica(data, 2, delta='auto', backend=bm.backend)
+            # result = varica.mvarica(data, 2, delta='auto', backend=bm.backend)
 
             # ICA does not define the ordering and sign of components
             # so wee need to test all combinations to find if one of them fits the original coefficients
             permutations = np.array(
-                [[0, 1, 2, 3, 4, 5], [0, 1, 4, 5, 2, 3], [2, 3, 4, 5, 0, 1], [2, 3, 0, 1, 4, 5], [4, 5, 0, 1, 2, 3],
-                 [4, 5, 2, 3, 0, 1]])
+                [
+                    [0, 1, 2, 3, 4, 5],
+                    [0, 1, 4, 5, 2, 3],
+                    [2, 3, 4, 5, 0, 1],
+                    [2, 3, 0, 1, 4, 5],
+                    [4, 5, 0, 1, 2, 3],
+                    [4, 5, 2, 3, 0, 1],
+                ]
+            )
             signperms = np.array(
-                [[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, -1, -1], [1, 1, -1, -1, 1, 1], [1, 1, -1, -1, -1, -1],
-                 [-1, -1, 1, 1, 1, 1], [-1, -1, 1, 1, -1, -1], [-1, -1, -1, -1, 1, 1], [-1, -1, -1, -1, -1, -1]])
+                [
+                    [1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, -1, -1],
+                    [1, 1, -1, -1, 1, 1],
+                    [1, 1, -1, -1, -1, -1],
+                    [-1, -1, 1, 1, 1, 1],
+                    [-1, -1, 1, 1, -1, -1],
+                    [-1, -1, -1, -1, 1, 1],
+                    [-1, -1, -1, -1, -1, -1],
+                ]
+            )
 
             best, d = np.inf, None
 
@@ -96,22 +117,23 @@ class TestMVARICA(unittest.TestCase):
                         best = err
                         d = c
 
-            #self.assertTrue(np.all(abs(d - b0) < 0.05))
+            # self.assertTrue(np.all(abs(d - b0) < 0.05))
             assert_allclose(d, b0, rtol=1e-2, atol=2e-2)
 
     def testFunctionality(self):
-        """ generate VAR signals, and apply the api to them
-            do this for every backend """
+        """generate VAR signals, and apply the api to them
+        do this for every backend"""
         np.random.seed(3141592)
 
         # original model coefficients
         b01 = np.zeros((3, 6))
         b02 = np.zeros((3, 6))
-        b01[1:3, 2:6] = [[0.4, -0.2, 0.3, 0.0],
-                         [-0.7, 0.0, 0.9, 0.0]]
-        b02[0:3, 2:6] = [[0.4, 0.0, 0.0, 0.0],
-                         [0.4, 0.0, 0.4, 0.0],
-                         [0.0, 0.0, 0.4, 0.0]]
+        b01[1:3, 2:6] = [[0.4, -0.2, 0.3, 0.0], [-0.7, 0.0, 0.9, 0.0]]
+        b02[0:3, 2:6] = [
+            [0.4, 0.0, 0.0, 0.0],
+            [0.4, 0.0, 0.4, 0.0],
+            [0.0, 0.0, 0.4, 0.0],
+        ]
         m0 = b01.shape[0]
         cl = np.array([0, 1, 0, 1, 0, 0, 1, 1, 1, 0])
         l = 200
@@ -135,16 +157,20 @@ class TestMVARICA(unittest.TestCase):
         sources[cl == 1, :, :] = sources2
 
         # simulate volume conduction... 3 sources smeared over 7 channels
-        mix = [[0.5, 1.0, 0.5, 0.2, 0.0, 0.0, 0.0],
-               [0.0, 0.2, 0.5, 1.0, 0.5, 0.2, 0.0],
-               [0.0, 0.0, 0.0, 0.2, 0.5, 1.0, 0.5]]
+        mix = [
+            [0.5, 1.0, 0.5, 0.2, 0.0, 0.0, 0.0],
+            [0.0, 0.2, 0.5, 1.0, 0.5, 0.2, 0.0],
+            [0.0, 0.0, 0.0, 0.2, 0.5, 1.0, 0.5],
+        ]
         data = datatools.dot_special(np.transpose(mix), sources)
         data += np.random.randn(*data.shape) * 0.001  # add small noise
 
         for backend_name, backend_gen in scot.backend.items():
-            np.random.seed(3141592)  # reset random seed so we're independent of module order
+            np.random.seed(
+                3141592
+            )  # reset random seed so we're independent of module order
 
-            api = scot.Workspace({'model_order': 2}, reducedim=3, backend=backend_gen())
+            api = scot.Workspace({"model_order": 2}, reducedim=3, backend=backend_gen())
 
             api.set_data(data)
 
@@ -155,7 +181,7 @@ class TestMVARICA(unittest.TestCase):
 
             api.do_mvarica()
 
-            self.assertEqual(api.get_connectivity('S').shape, (3, 3, 512))
+            self.assertEqual(api.get_connectivity("S").shape, (3, 3, 512))
 
             self.assertFalse(np.any(np.isnan(api.activations_)))
             self.assertFalse(np.any(np.isinf(api.activations_)))
@@ -164,54 +190,69 @@ class TestMVARICA(unittest.TestCase):
 
             api.fit_var()
 
-            self.assertEqual(api.get_connectivity('S').shape, (3, 3, 512))
-            self.assertEqual(api.get_tf_connectivity('S', 100, 50).shape, (3, 3, 512, (l-100)//50))
-            
-            tfc1 = api.get_tf_connectivity('PDC', 100, 5, baseline=None)        # no baseline
-            tfc2 = api.get_tf_connectivity('PDC', 100, 5, baseline=[110, -10])  # invalid baseline
-            tfc3 = api.get_tf_connectivity('PDC', 100, 5, baseline=[0, 0])      # one-window baseline
+            self.assertEqual(api.get_connectivity("S").shape, (3, 3, 512))
+            self.assertEqual(
+                api.get_tf_connectivity("S", 100, 50).shape,
+                (3, 3, 512, (l - 100) // 50),
+            )
+
+            tfc1 = api.get_tf_connectivity("PDC", 100, 5, baseline=None)  # no baseline
+            tfc2 = api.get_tf_connectivity(
+                "PDC", 100, 5, baseline=[110, -10]
+            )  # invalid baseline
+            tfc3 = api.get_tf_connectivity(
+                "PDC", 100, 5, baseline=[0, 0]
+            )  # one-window baseline
             tfc4 = tfc1 - tfc1[:, :, :, [0]]
-            tfc5 = api.get_tf_connectivity('PDC', 100, 5, baseline=[-np.inf, np.inf])  # full trial baseline
+            tfc5 = api.get_tf_connectivity(
+                "PDC", 100, 5, baseline=[-np.inf, np.inf]
+            )  # full trial baseline
             tfc6 = tfc1 - np.mean(tfc1, axis=3, keepdims=True)
             self.assertTrue(np.allclose(tfc1, tfc2))
             self.assertTrue(np.allclose(tfc3, tfc4))
             self.assertTrue(np.allclose(tfc5, tfc6, rtol=1e-05, atol=1e-06))
 
             api.set_data(data, cl)
-            
+
             self.assertFalse(np.any(np.isnan(api.data_)))
             self.assertFalse(np.any(np.isinf(api.data_)))
-            
+
             api.do_cspvarica()
-            
-            self.assertEqual(api.get_connectivity('S').shape, (3,3,512))
+
+            self.assertEqual(api.get_connectivity("S").shape, (3, 3, 512))
 
             self.assertFalse(np.any(np.isnan(api.activations_)))
             self.assertFalse(np.any(np.isinf(api.activations_)))
-            
+
             for c in np.unique(cl):
                 api.set_used_labels([c])
 
                 api.fit_var()
-                fc = api.get_connectivity('S')
+                fc = api.get_connectivity("S")
                 self.assertEqual(fc.shape, (3, 3, 512))
 
-                tfc = api.get_tf_connectivity('S', 100, 50)
-                self.assertEqual(tfc.shape, (3, 3, 512, (l-100)//50))
+                tfc = api.get_tf_connectivity("S", 100, 50)
+                self.assertEqual(tfc.shape, (3, 3, 512, (l - 100) // 50))
 
             api.set_data(data)
             api.remove_sources([0, 2])
             api.fit_var()
-            self.assertEqual(api.get_connectivity('S').shape, (1, 1, 512))
-            self.assertEqual(api.get_tf_connectivity('S', 100, 50).shape, (1, 1, 512, (l-100)//50))
+            self.assertEqual(api.get_connectivity("S").shape, (1, 1, 512))
+            self.assertEqual(
+                api.get_tf_connectivity("S", 100, 50).shape,
+                (1, 1, 512, (l - 100) // 50),
+            )
 
             try:
                 api.optimize_var()
             except NotImplementedError:
                 pass
             api.fit_var()
-            self.assertEqual(api.get_connectivity('S').shape, (1, 1, 512))
-            self.assertEqual(api.get_tf_connectivity('S', 100, 50).shape, (1, 1, 512, (l-100)//50))
+            self.assertEqual(api.get_connectivity("S").shape, (1, 1, 512))
+            self.assertEqual(
+                api.get_tf_connectivity("S", 100, 50).shape,
+                (1, 1, 512, (l - 100) // 50),
+            )
 
     def test_premixing(self):
         api = scot.Workspace(VAR(1))
@@ -220,28 +261,34 @@ class TestMVARICA(unittest.TestCase):
     def test_plotting(self):
         np.random.seed(3141592)
 
-        api = scot.Workspace(VAR(1), locations=[[0, 0, 1], [1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0]])
+        api = scot.Workspace(
+            VAR(1), locations=[[0, 0, 1], [1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0]]
+        )
 
         api.set_data(np.random.randn(10, 5, 10), [1, 0] * 5)
         api.do_mvarica()
 
         api.plot_source_topos()
 
-        for diag in ['S', 'fill', 'topo']:
+        for diag in ["S", "fill", "topo"]:
             for outside in [True, False]:
                 api.plot_diagonal = diag
                 api.plot_outside_topo = outside
 
                 fig = api.plot_connectivity_topos()
-                api.get_connectivity('PHI', plot=fig)
-                api.get_surrogate_connectivity('PHI', plot=fig, repeats=5)
-                api.get_bootstrap_connectivity('PHI', plot=fig, repeats=5)
-                api.get_tf_connectivity('PHI', winlen=2, winstep=1, plot=fig)
-                api.compare_conditions([0], [1], 'PHI', plot=fig, repeats=5)
+                api.get_connectivity("PHI", plot=fig)
+                api.get_surrogate_connectivity("PHI", plot=fig, repeats=5)
+                api.get_bootstrap_connectivity("PHI", plot=fig, repeats=5)
+                api.get_tf_connectivity("PHI", winlen=2, winstep=1, plot=fig)
+                api.compare_conditions([0], [1], "PHI", plot=fig, repeats=5)
 
     def test_random_state(self):
         np.random.seed(10)
-        api = scot.Workspace(VAR(1),locations=[[0, 0, 1], [1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0]], reducedim=None)
+        api = scot.Workspace(
+            VAR(1),
+            locations=[[0, 0, 1], [1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0]],
+            reducedim=None,
+        )
         api.set_data(np.random.randn(10, 5, 10), [1, 0] * 5)
 
         # test MVARICA
@@ -261,9 +308,8 @@ class TestMVARICA(unittest.TestCase):
     def test_source_selection(self):
         var = VAR(2)
         var.coef = np.random.randn(16, 4)
-        x = var.simulate([500, 50],
-                         lambda: np.random.randn(16).dot(np.eye(16, 16)))
-        api = scot.Workspace({'model_order': 2})
+        x = var.simulate([500, 50], lambda: np.random.randn(16).dot(np.eye(16, 16)))
+        api = scot.Workspace({"model_order": 2})
         api.set_data(x)
         self.assertRaises(RuntimeError, api.keep_sources, [0, 5, 11, 12])
         self.assertRaises(RuntimeError, api.remove_sources, [1, 2, 8, 14])
@@ -282,5 +328,5 @@ class TestMVARICA(unittest.TestCase):
 
     def testBackendRegression(self):
         """Regression test for Github issue #103."""
-        ws = scot.Workspace({'model_order': 3}, backend=None)
+        ws = scot.Workspace({"model_order": 3}, backend=None)
         self.assertIsNotNone(ws.backend_)

--- a/scot/tests/test_plotting.py
+++ b/scot/tests/test_plotting.py
@@ -29,7 +29,7 @@ class TestFunctionality(unittest.TestCase):
     def test_topoplots(self):
         locs, vals, topo, maps = self.locs, self.vals, self.topo, self.maps
 
-        self.assertEquals(len(maps), len(vals))     # should get two topo maps
+        self.assertEqual(len(maps), len(vals))     # should get two topo maps
 
         self.assertTrue(np.allclose(maps[0], maps[0].T))    # first map: should be rotationally identical (blob in the middle)
         self.assertTrue(np.alltrue(maps[1] == 0))           # second map: should be all zeros

--- a/scot/tests/test_var_sklearn.py
+++ b/scot/tests/test_var_sklearn.py
@@ -4,8 +4,7 @@
 
 import unittest
 
-from numpy.testing.utils import assert_array_almost_equal
-from numpy.testing.utils import assert_equal
+from numpy.testing import assert_array_almost_equal, assert_equal
 
 import numpy as np
 from sklearn.linear_model import Ridge, RidgeCV, Lasso, LassoLars, ElasticNet

--- a/scot/tests/test_xvschema.py
+++ b/scot/tests/test_xvschema.py
@@ -75,29 +75,29 @@ class TestSklearn(unittest.TestCase):
         pass
 
     def test_leave1out(self):
-        from sklearn.cross_validation import LeaveOneOut
+        from sklearn.model_selection import LeaveOneOut
         n_trials = 10
         xv1 = scot.xvschema.multitrial(n_trials)
-        xv2 = LeaveOneOut(n_trials)
+        xv2 = LeaveOneOut().split(np.arange(n_trials))
         self._comparexv(xv1, xv2)
 
     def test_kfold(self):
-        from sklearn.cross_validation import KFold
+        from sklearn.model_selection import KFold
         n_trials = 15
         n_blocks = 5
         xv1 = scot.xvschema.make_nfold(n_blocks)(n_trials)
-        xv2 = KFold(n_trials, n_folds=n_blocks, shuffle=False)
+        xv2 = KFold(n_splits=n_blocks, shuffle=False).split(np.arange(n_trials))
         self._comparexv(xv1, xv2)
 
     def test_application(self):
         from scot.var import VAR
-        from sklearn.cross_validation import LeaveOneOut, KFold
+        from sklearn.model_selection import LeaveOneOut, KFold
         np.random.seed(42)
         x = np.random.randn(10, 3, 15)
 
-        var = VAR(3, xvschema=lambda n, _: LeaveOneOut(n)).optimize_delta_bisection(x)
+        var = VAR(3, xvschema=lambda n, _: LeaveOneOut().split(range(n))).optimize_delta_bisection(x)
         self.assertGreater(var.delta, 0)
-        var = VAR(3, xvschema=lambda n, _: KFold(n, 5)).optimize_delta_bisection(x)
+        var = VAR(3, xvschema=lambda n, _: KFold(5).split(range(n))).optimize_delta_bisection(x)
         self.assertGreater(var.delta, 0)
 
     def _comparexv(self, xv1, xv2):

--- a/scot/var.py
+++ b/scot/var.py
@@ -77,7 +77,7 @@ class VAR(VARBase):
         self.coef = b.transpose()
 
         self.residuals = data - self.predict(data)
-        self.rescov = sp.cov(cat_trials(self.residuals[:, :, self.p:]))
+        self.rescov = np.cov(cat_trials(self.residuals[:, :, self.p:]))
 
         return self
 

--- a/scot/varbase.py
+++ b/scot/varbase.py
@@ -205,7 +205,7 @@ class VARBase(object):
                     y[i, :, s] += self.coef[:, (k - 1)::p].dot(y[i - k, :, s])
 
         self.residuals = res[10 * p:, :, :].T
-        self.rescov = sp.cov(cat_trials(self.residuals).T, rowvar=False)
+        self.rescov = np.cov(cat_trials(self.residuals).T, rowvar=False)
 
         return y[10 * p:, :, :].transpose([2, 1, 0])
 


### PR DESCRIPTION
The good news: pytest works out of the box!

Using Python 3.10.something I installed recent versions of our dependencies, ran pytest, and it worked. Well, mostly... I had to fix a few uses of floats and adjust to changes in the APIs of a few dependencies.

TODO
- [x] Fix ~2000 warnings (many deprecations), maybe in separate PR?
- [ ] Use pytest's flat test functions?
  - @cbrnr  Can you remind me what's wrong with test classes? Tests seem nicely structured that way.