### PR TITLE
Changes to get PDC method in connectivity to work

### DIFF
--- a/scot/var.py
+++ b/scot/var.py
@@ -72,7 +72,7 @@ class VAR(VARBase):
             # regularized least squares (ridge regression)
             x, y = self._construct_eqns_rls(data)
 
-        b, res, rank, s = sp.linalg.lstsq(x, y)
+        b, res, rank, s = np.linalg.lstsq(x, y)
 
         self.coef = b.transpose()
 

--- a/scot/varbase.py
+++ b/scot/varbase.py
@@ -340,7 +340,7 @@ class VARBase(object):
 def _construct_var_eqns(data, p, delta=None):
         """Construct VAR equation system (optionally with RLS constraint).
         """
-        t, m, l = np.shape(data)
+        t, l, m = np.shape(data)
         n = (l - p) * t  # number of linear relations
         rows = n if delta is None else n + m * p
 
@@ -348,14 +348,14 @@ def _construct_var_eqns(data, p, delta=None):
         x = np.zeros((rows, m * p))
         for i in range(m):
             for k in range(1, p + 1):
-                x[:n, i * p + k - 1] = np.reshape(data[:, i, p - k:-k].T, n)
+                x[:n, i * p + k - 1] = np.reshape(data[:, p - k:-k, i], n)
         if delta is not None:
             np.fill_diagonal(x[n:, :], delta)
 
         # Construct vectors yi (response variables for each channel i)
         y = np.zeros((rows, m))
         for i in range(m):
-            y[:n, i] = np.reshape(data[:, i, p:].T, n)
+            y[:n, i] = np.reshape(data[:, p:, i], n)
 
         return x, y
 


### PR DESCRIPTION
Basically to run something simple like
data = np.stack([x0, x1, x2], axis=1).reshape(1, -1, 3)
model = VAR(3) 
model = model.fit(data)
conn = Connectivity(model.coef, nfft=10)
conn_matrix = conn.PDC()

I had to change an sp depreciation and adjust _construct_var_eqns to give me a proper 3x3 matrix at the end

Very possible I've used it wrong but thought I'd post this anyways :)